### PR TITLE
Remove `.Site.BaseURL`

### DIFF
--- a/layouts/partials/components/breadcrumb.html
+++ b/layouts/partials/components/breadcrumb.html
@@ -1,13 +1,13 @@
 {{ $context := .Context }}
 {{ $class := .Class }}
-{{ $base := site.BaseURL }}
+{{ $base := site.Home.Permalink }}
 
 
 <ul class="{{ $class }} inline-flex space-x-1 capitalize">
   <li>
     <a
       class="text-primary dark:text-darkmode-primary"
-      href="{{ $base | relLangURL }}">
+      href="{{ $base }}">
       {{ i18n "home" | default "Home" }}
     </a>
     <span class="inlin-block mr-1">/</span>

--- a/layouts/partials/components/language-switcher.html
+++ b/layouts/partials/components/language-switcher.html
@@ -2,7 +2,7 @@
 {{ $class := .Class }}
 {{ $context := .Context }}
 {{ $pageLang := $context.Lang }}
-{{ $base:= urls.Parse site.BaseURL }}
+{{ $base:= urls.Parse site.Home.Permalink }}
 {{ $siteLanguages := site.Home.AllTranslations }}
 {{ $pageLink := replace (replace $context.RelPermalink (add $pageLang "/") "") $base.Path "/" }}
 

--- a/layouts/partials/essentials/footer.html
+++ b/layouts/partials/essentials/footer.html
@@ -5,7 +5,7 @@
         <!-- navbar brand/logo -->
         <a
           class="navbar-brand inline-block"
-          href="{{ site.BaseURL | relLangURL }}">
+          href="{{ site.Home.Permalink }}">
           {{ partial "logo" }}
         </a>
       </div>
@@ -19,7 +19,7 @@
                 {{ end }}
                 href="{{ if findRE `^#` .URL }}
                   {{ if not $.IsHome }}
-                    {{ site.BaseURL | relLangURL }}
+                    {{ site.Home.Permalink }}
                   {{ end }}{{ .URL }}
                 {{ else }}
                   {{ .URL | relLangURL }}

--- a/layouts/partials/essentials/footer.html
+++ b/layouts/partials/essentials/footer.html
@@ -5,7 +5,7 @@
         <!-- navbar brand/logo -->
         <a
           class="navbar-brand inline-block"
-          href="{{ site.Home.Permalink }}">
+          href="{{ site.Home.RelPermalink }}">
           {{ partial "logo" }}
         </a>
       </div>
@@ -19,7 +19,7 @@
                 {{ end }}
                 href="{{ if findRE `^#` .URL }}
                   {{ if not $.IsHome }}
-                    {{ site.Home.Permalink }}
+                    {{ site.Home.RelPermalink }}
                   {{ end }}{{ .URL }}
                 {{ else }}
                   {{ .URL | relLangURL }}

--- a/layouts/partials/essentials/header.html
+++ b/layouts/partials/essentials/header.html
@@ -4,7 +4,7 @@
     <!-- logo -->
     <div class="order-0">
       <!-- navbar brand/logo -->
-      <a class="navbar-brand block" href="{{ site.BaseURL | relLangURL }}">
+      <a class="navbar-brand block" href="{{ site.Home.Permalink }}">
         {{ partial "logo" }}
       </a>
     </div>
@@ -64,7 +64,7 @@
                     {{ end }}
                     href="{{- if findRE `^#` .URL -}}
                       {{- if not $.IsHome -}}
-                        {{- site.BaseURL | relLangURL -}}
+                        {{- site.Home.Permalink -}}
                       {{- end }}
                       {{- .URL -}}
                     {{- else -}}
@@ -85,7 +85,7 @@
               {{ end }}
               href="{{- if findRE `^#` .URL -}}
                 {{- if not $.IsHome -}}
-                  {{- site.BaseURL | relLangURL -}}
+                  {{- site.Home.Permalink -}}
                 {{- end }}{{- .URL -}}
               {{- else -}}
                 {{- .URL | relLangURL -}}

--- a/layouts/partials/essentials/header.html
+++ b/layouts/partials/essentials/header.html
@@ -4,7 +4,7 @@
     <!-- logo -->
     <div class="order-0">
       <!-- navbar brand/logo -->
-      <a class="navbar-brand block" href="{{ site.Home.Permalink }}">
+      <a class="navbar-brand block" href="{{ site.Home.RelPermalink }}">
         {{ partial "logo" }}
       </a>
     </div>
@@ -64,7 +64,7 @@
                     {{ end }}
                     href="{{- if findRE `^#` .URL -}}
                       {{- if not $.IsHome -}}
-                        {{- site.Home.Permalink -}}
+                        {{- site.Home.RelPermalink -}}
                       {{- end }}
                       {{- .URL -}}
                     {{- else -}}
@@ -85,7 +85,7 @@
               {{ end }}
               href="{{- if findRE `^#` .URL -}}
                 {{- if not $.IsHome -}}
-                  {{- site.Home.Permalink -}}
+                  {{- site.Home.RelPermalink -}}
                 {{- end }}{{- .URL -}}
               {{- else -}}
                 {{- .URL | relLangURL -}}


### PR DESCRIPTION
> There is never a great reason to call .Site.BaseURL from a template. Hopefully we will deprecate that method at some point. Use the `absURL` and `absLangURL` functions instead.

[JMooring](https://discourse.gohugo.io/t/46692/4)

https://gohugo.io/methods/site/home/

