### PR TITLE
toggle active on correct element 

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -10,7 +10,7 @@
 
   dropdownMenuToggler.forEach((toggler) => {
     toggler?.addEventListener("click", (e) => {
-      e.target.parentElement.classList.toggle("active");
+      e.target.closest('.nav-item').classList.toggle("active");
     });
   });
 

--- a/assets/scss/navigation.scss
+++ b/assets/scss/navigation.scss
@@ -36,7 +36,7 @@ input#nav-toggle:checked ~ #nav-menu {
 // }
 
 .nav-link {
-  @apply text-dark hover:text-primary dark:text-darkmode-dark dark:hover:text-darkmode-primary block p-3 font-semibold transition lg:px-2 lg:py-3;
+  @apply text-dark hover:text-primary dark:text-darkmode-dark dark:hover:text-darkmode-primary block p-3 cursor-pointer font-semibold transition lg:px-2 lg:py-3;
 }
 
 .nav-dropdown {


### PR DESCRIPTION
Submenu toggle in mobile menu does not work if SVG icon is clicked. 

Root cause:  active should be toggled on span.nav-item. clicking on svg was toggling active its parent - span.nav-link instead, which does not toggle sub-menu visibility

![image](https://github.com/zeon-studio/hugoplate/assets/5070211/ebe83066-8225-4327-90c3-051f1f69cf23)
