### PR TITLE
Map HTTP 404 explicitly in Vercel

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -7,5 +7,15 @@
         "distDir": "public"
       }
     }
+  ],
+  "routes": [
+    {
+      "handle": "filesystem"
+    },
+    {
+      "src": "/(.*)",
+      "status": 404,
+      "dest": "/404.html"
+    }
   ]
 }


### PR DESCRIPTION
Previously, deploying a fresh setup of Hugoplate to Vercel would not correctly map the `404.html`. Instead, the default not-found page from Vercel was shown. This change adds an explicit redirect to the Vercel config, such that on HTTP 404, clients are redirected to the 404 page provided by Hugoplate.