### PR TITLE
Disable right border and padding on search button in some cases / setting for widgets visibility

### DIFF
--- a/exampleSite/config/_default/params.toml
+++ b/exampleSite/config/_default/params.toml
@@ -81,6 +81,7 @@ button = "I Accept"
 
 ######################## sidebar widgets #########################
 [widgets]
+enable = true 
 sidebar = ["categories", "tags"]
 
 

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -6,11 +6,20 @@
     <div class="container">
       <div class="row gx-5">
         <!-- blog posts -->
+        {{ if (site.Params.widgets.enable | default true) }}
         <div class="lg:col-8">
+        {{ else }}
+        <div class="lg:col-12">
+        {{ end }}
           <div class="row">
             {{ $paginator:= .Paginate .RegularPages }}
             {{ range $paginator.Pages }}
-              <div class="md:col-6 mb-14">
+              <div class="
+              {{- if and (gt $paginator.Pages 2) (not (site.Params.widgets.enable | default true)) -}}
+                md:col-6 lg:col-4 
+              {{- else -}}
+                md:col-6
+              {{- end }} mb-14">
                 {{ partial "components/blog-card" . }}
               </div>
             {{ end }}
@@ -18,11 +27,13 @@
           {{ partial "components/pagination.html" . }}
         </div>
         <!-- sidebar -->
+        {{ if (site.Params.widgets.enable | default true) }}
         <div class="lg:col-4">
           <!-- widget -->
           {{ $widget:= site.Params.widgets.sidebar }}
           {{ partialCached "widgets/widget-wrapper" ( dict "Widgets" $widget "Scope" . ) }}
         </div>
+        {{ end }}
       </div>
     </div>
   </section>

--- a/layouts/partials/essentials/header.html
+++ b/layouts/partials/essentials/header.html
@@ -111,7 +111,11 @@
         {{ if .enable }}
           <button
             aria-label="search"
-            class="border-border text-dark hover:text-primary dark:border-darkmode-border mr-5 inline-block border-r pr-5 text-xl dark:text-white dark:hover:text-darkmode-primary"
+            {{ if and (not site.Params.navigation_button.enable) (not site.Params.theme_switcher)}}
+              class="border-border text-dark hover:text-primary dark:border-darkmode-border mr-5 inline-block border-r lg:border-r-0 pr-5 lg:pr-0 text-xl dark:text-white dark:hover:text-darkmode-primary"
+            {{ else }}
+              class="border-border text-dark hover:text-primary dark:border-darkmode-border mr-5 inline-block border-r pr-5 text-xl dark:text-white dark:hover:text-darkmode-primary"
+            {{ end }}
             data-target="search-modal">
             <i class="fa-solid fa-search"></i>
           </button>


### PR DESCRIPTION
Only when the normal top menu is visible (above lg breakpoint):
If both navigation_button and theme_switcher are disabled, the right border and right padding are removed from the search button.
