### PR TITLE
With other buttons disabled, don't always show vertical search button divider

### DIFF
--- a/layouts/partials/essentials/header.html
+++ b/layouts/partials/essentials/header.html
@@ -111,7 +111,11 @@
         {{ if .enable }}
           <button
             aria-label="search"
+            {{ if and (not site.Params.navigation_button.enable) (not site.Params.theme_switcher)}}
+            class="border-border text-dark hover:text-primary dark:border-darkmode-border mr-5 inline-block border-r lg:border-r-0 pr-5 lg:pr-0 text-xl dark:text-white dark:hover:text-darkmode-primary"
+            {{ else }}
             class="border-border text-dark hover:text-primary dark:border-darkmode-border mr-5 inline-block border-r pr-5 text-xl dark:text-white dark:hover:text-darkmode-primary"
+            {{ end }}
             data-target="search-modal">
             <i class="fa-solid fa-search"></i>
           </button>


### PR DESCRIPTION
On lg breakpoint and above:

 - Remove divider and pr from search button when other buttons are disabled