### PR TITLE
Header template enhancement and French 404 template file

### DIFF
--- a/layouts/404.fr.html
+++ b/layouts/404.fr.html
@@ -1,0 +1,25 @@
+{{ define "main" }}
+  <section class="section-sm text-center">
+    <div class="container">
+      <div class="row justify-center">
+        <div class="sm:col-10 md:col-8 lg:col-6">
+          <span
+            class="text-[8rem] block font-bold text-dark dark:text-darkmode-dark">
+            404
+          </span>
+          <h1 class="h2 mb-4">Page non trouvée</h1>
+          <div class="content">
+            <p>
+              La page que vous recherchez n'existe pas ou plus.
+            </p>
+          </div>
+          <a
+            href="{{ site.BaseURL | relLangURL }}"
+            class="btn btn-primary mt-8">
+            Retour
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+{{ end }}

--- a/layouts/partials/essentials/header.html
+++ b/layouts/partials/essentials/header.html
@@ -97,11 +97,20 @@
       {{ end }}
       {{ if site.Params.navigation_button.enable }}
         <li class="mt-4 inline-block lg:hidden">
+          {{ if site.Params.navigation_button.x_external }}
+          <a
+            target="_blank"
+            class="btn btn-outline-primary btn-sm"
+            href="{{ site.Params.navigation_button.link | relLangURL }}">
+            {{ site.Params.navigation_button.label }}
+          </a>
+          {{ else }}
           <a
             class="btn btn-outline-primary btn-sm"
             href="{{ site.Params.navigation_button.link | relLangURL }}">
             {{ site.Params.navigation_button.label }}
           </a>
+          {{ end }}
         </li>
       {{ end }}
     </ul>
@@ -128,11 +137,20 @@
 
       <!-- navigation btn -->
       {{ if site.Params.navigation_button.enable }}
+        {{ if site.Params.navigation_button.x_external }}
+        <a
+          target="_blank"
+          href="{{ site.Params.navigation_button.link | relLangURL }}"
+          class="btn btn-outline-primary btn-sm hidden lg:inline-block">
+          {{ site.Params.navigation_button.label }}
+        </a>
+        {{ else }}
         <a
           href="{{ site.Params.navigation_button.link | relLangURL }}"
           class="btn btn-outline-primary btn-sm hidden lg:inline-block">
           {{ site.Params.navigation_button.label }}
         </a>
+        {{ end }}
       {{ end }}
     </div>
   </nav>


### PR DESCRIPTION
I propose the following enhancements:
 
- add the capability to the partials/essentials/header.html file to open or not a new browser window for an HREF link, using a property defined in the params.tom file like:

`# Navigation button
[navigation_button]
enable = true
# New params added in template by GLE
x_external = true`

- add a 404 french template file in /layouts as 404.fr.html

