### PR TITLE
fix: Cannot apply unknown utility class: dark:fill-dark

### DIFF
--- a/assets/css/module-overrides.css
+++ b/assets/css/module-overrides.css
@@ -9,7 +9,7 @@
 }
 
 .share-icons .share-icon svg {
-  @apply dark:fill-dark;
+  @apply dark:fill-current;
 }
 
 /* notice */


### PR DESCRIPTION
Error: error building site: TAILWINDCSS: failed to transform "/css/main.css" (text/css): (node:69032) Warning: To load an ES module, set "type": "module" in the package.json or use the .mjs extension. (Use `node --trace-warnings ...` to show where the warning was created) Error: Cannot apply unknown utility class: dark:fill-dark