### PR TITLE
example site: fix warnings

### DIFF
--- a/exampleSite/content/english/sections/call-to-action.md
+++ b/exampleSite/content/english/sections/call-to-action.md
@@ -9,6 +9,6 @@ button:
   link: "https://github.com/zeon-studio/hugoplate"
 
 # don't create a separate page
-_build:
+build:
   render: "never"
 ---

--- a/exampleSite/content/english/sections/testimonial.md
+++ b/exampleSite/content/english/sections/testimonial.md
@@ -26,6 +26,6 @@ testimonials:
     content: "Lorem ipsum dolor sit amet consectetur adipisicing elit. Qui iusto illo molestias, assumenda expedita commodi inventore non itaque molestiae voluptatum dolore, facilis sapiente, repellat veniam."
 
 # don't create a separate page
-_build:
+build:
   render: "never"
 ---

--- a/exampleSite/go.mod
+++ b/exampleSite/go.mod
@@ -27,4 +27,5 @@ require (
 	github.com/gethugothemes/hugo-modules/table-of-contents v0.0.0-20250409040650-2f989f5e8ea1 // indirect
 	github.com/gethugothemes/hugo-modules/videos v0.0.0-20250409040650-2f989f5e8ea1 // indirect
 	github.com/hugomods/mermaid v0.1.4 // indirect
+	github.com/zeon-studio/hugoplate v0.0.0-20250410045301-d61c360b8948 // indirect
 )

--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -28,7 +28,7 @@ shortname = 'themefisher-template' # we use disqus to show comments in blog post
 
 ########################## Permalinks ############################
 [permalinks.page]
-"pages" = "/:slugorfilename/"
+"pages" = "/:slugorcontentbasename/"
 
 
 ########################## Pagination ############################

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,5 +3,5 @@ publish = "public"
 command = "yarn project-setup; yarn build"
 
 [build.environment]
-HUGO_VERSION = "0.144.2"
-GO_VERSION = "1.24.0"
+HUGO_VERSION = "0.146.5"
+GO_VERSION = "1.24.2"

--- a/package.json
+++ b/package.json
@@ -19,12 +19,12 @@
     "format": "prettier -w ."
   },
   "devDependencies": {
-    "@tailwindcss/cli": "^4.1.3",
+    "@tailwindcss/cli": "^4.1.4",
     "@tailwindcss/forms": "^0.5.10",
     "@tailwindcss/typography": "^0.5.16",
     "prettier": "^3.5.3",
     "prettier-plugin-go-template": "0.0.15",
     "prettier-plugin-tailwindcss": "^0.6.11",
-    "tailwindcss": "^4.1.3"
+    "tailwindcss": "^4.1.4"
   }
 }

--- a/vercel-build.sh
+++ b/vercel-build.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # default versions
-GO_VERSION='1.24.0';
-HUGO_VERSION='0.144.2';
+GO_VERSION='1.24.2';
+HUGO_VERSION='0.146.5';
 
 echo "USING NODE VERSION: $(node -v)"
 


### PR DESCRIPTION
When previewing example site with latest hugo version 0.146.5, several warnings are printed out.
This PR fixes these warnings.