### PR TITLE
fix: add smooth scrolling for table of contents with optional toggle in config

### DIFF
--- a/assets/js/anchor.js
+++ b/assets/js/anchor.js
@@ -1,0 +1,21 @@
+document.addEventListener('DOMContentLoaded', function () {
+    const toc = document.getElementById('TableOfContents');
+    const navbar = document.querySelector('.navbar');
+    if (toc && navbar) {
+        toc.querySelectorAll('a[href^="#"]').forEach((anchor) => {
+            anchor.addEventListener('click', function (e) {
+                e.preventDefault();
+                const targetId = decodeURIComponent(this.getAttribute('href').substring(1));
+                const targetElement = document.getElementById(targetId);
+                if (targetElement) {
+                    const navbarHeight = navbar.offsetHeight;
+                    const targetPosition = targetElement.getBoundingClientRect().top + window.pageYOffset - navbarHeight - 70;
+                    window.scrollTo({
+                        top: targetPosition,
+                        behavior: 'smooth',
+                    });
+                }
+            });
+        });
+    }
+});

--- a/exampleSite/config/_default/params.toml
+++ b/exampleSite/config/_default/params.toml
@@ -86,6 +86,9 @@ expire_days = 60
 content = "This site uses cookies. By continuing to use this website, you agree to their use."
 button = "I Accept"
 
+[toc]
+enable = true
+
 # diagrams
 [mermaid]
 js_url = 'https://cdn.jsdelivr.net/npm/mermaid@latest/dist/mermaid.esm.min.mjs'

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -41,7 +41,13 @@
             </li>
           </ul>
           <div class="content mb-10">
-            {{ partial "toc.html" (dict "Class" "blog" "Collapsed" false "TableOfContents" .TableOfContents ) }}
+            {{ if site.Params.toc.enable }}
+              {{ partial "toc.html" (dict "Class" "blog" "Collapsed" false "TableOfContents" .TableOfContents ) }}
+              {{ if site.Params.navbar_fixed }}
+                {{ $jsAnchor := resources.Get "js/anchor.js" }}
+                <script src="{{ $jsAnchor.RelPermalink }}" integrity="{{ $jsAnchor.Data.Integrity }}" crossorigin="anonymous"></script>
+              {{ end }}
+            {{ end }}
             {{ .Content }}
           </div>
           <div class="row items-start justify-between">


### PR DESCRIPTION
## Changes

- Add an option flag to enable TOC
- Fix the issue with TOC anchor position when the nav bar is fixed

## Summary

This pull request introduces a Table of Contents (ToC) feature for blog posts, including both configuration and implementation. The ToC is now optionally enabled via site parameters, and when active, includes smooth scrolling behavior that accounts for a fixed navbar. The changes are grouped below by theme.

**Table of Contents Feature:**

* Added a `[toc]` section with an `enable` flag to the site configuration (`params.toml`), allowing ToC display to be toggled.
* Updated the blog post template (`single.html`) to conditionally render the ToC partial when the feature is enabled, and inject the anchor scrolling script if a fixed navbar is configured.

**Smooth Anchor Scrolling:**

* Added `assets/js/anchor.js`, which implements smooth scrolling for ToC anchor links, adjusting for the height of a fixed navbar and an additional offset for better visibility.